### PR TITLE
Add support for local host IPs

### DIFF
--- a/ssl
+++ b/ssl
@@ -66,7 +66,7 @@ fi
 # Check if there is an input
 ##
 if [[ $1 ]]; then
-	host $1 > /dev/null
+	host -t A $1 > /dev/null
 	if [ $? -eq 0 ]; then
 		echo -e "$(ColorRed '#') $(ColorGreen 'Checking Domain/Hostname:')\n\t$1"
 	else


### PR DESCRIPTION
If there's a local host entry for the domain.

Resolve only the `A` record without trying to ping it, since some servers disable ping support. This should still work with CNAME based domains.